### PR TITLE
Rework the API to use a base Hooks class

### DIFF
--- a/hooks/src/main/kotlin/com/intuit/hooks/BaseHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/BaseHook.kt
@@ -70,7 +70,9 @@ public abstract class SyncBaseHook<F : Function<*>>(type: String) : BaseHook<F>(
     }
 }
 
-public abstract class BaseHook<F : Function<*>>(private val type: String) {
+public sealed class Hook
+
+public abstract class BaseHook<F : Function<*>>(private val type: String) : Hook() {
     protected var taps: List<TapInfo<F>> = emptyList(); private set
     protected open val interceptors: Interceptors<F> = Interceptors()
 

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HookValidationErrors.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HookValidationErrors.kt
@@ -10,7 +10,7 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
@@ -28,18 +28,18 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
-                abstract val syncHook: SyncHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
 
         val (_, result) = compile(testHooks)
         result.assertOk()
-        result.assertContainsMessages("Hook property must be annotated with respective DSL annotation for SyncHook<*>")
+        result.assertContainsMessages("Hook property must be annotated with a DSL annotation")
     }
 
     @Test fun `hook property has too many hook annotations`() {
@@ -47,13 +47,13 @@ class HookValidationErrors {
             "TestHooks.kt",
             """
             import com.intuit.hooks.BailResult
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<() -> Unit>
                 @SyncBail<() -> BailResult<Int>>
-                abstract val syncHook: SyncHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -63,36 +63,16 @@ class HookValidationErrors {
         result.assertContainsMessages("This hook has more than a single hook DSL annotation: [@Sync, @SyncBail]")
     }
 
-    @Test fun `hook property type does not match annotation`() {
-        val testHooks = SourceFile.kotlin(
-            "TestHooks.kt",
-            """
-            import com.intuit.hooks.BailResult
-            import com.intuit.hooks.SyncHook
-            import com.intuit.hooks.dsl.Hooks
-            
-            internal abstract class TestHooks : Hooks() {
-                @SyncBail<() -> BailResult<Int>>
-                abstract val syncHook: SyncHook<*>
-            }
-            """
-        )
-
-        val (_, result) = compile(testHooks)
-        result.assertOk()
-        result.assertContainsMessages("Hook property type (SyncHook<*>) does not match annotation hook type (@SyncBail")
-    }
-
     @Test fun `async hooks must has suspend modifier`() {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeries<() -> Unit>
-                abstract val syncHook: AsyncSeriesHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -106,12 +86,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @SyncWaterfall<() -> String>
-                abstract val syncHook: SyncWaterfallHook<*, *>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -125,12 +105,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @SyncWaterfall<(Int, Int) -> Unit>
-                abstract val syncHook: SyncWaterfallHook<*, *>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -144,12 +124,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesBailHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeriesWaterfall<() -> String>
-                abstract val realBad: AsyncSeriesBailHook<*, *>
+                abstract val realBad: Hook
                 abstract val state: Int
             }
             """
@@ -158,7 +138,6 @@ class HookValidationErrors {
         val (_, result) = compile(testHooks)
         result.assertOk()
         result.assertContainsMessages(
-            "Hook property type (AsyncSeriesBailHook<*, *>) does not match annotation hook type (@AsyncSeriesWaterfall)",
             "Async hooks must be defined with a suspend function signature",
             "Waterfall hooks must take at least one parameter",
             "Waterfall hooks must specify the same types for the first parameter and the return type",

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
@@ -9,12 +9,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
             import com.intuit.hooks.dsl.Hooks
+            import com.intuit.hooks.Hook
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(String) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -46,12 +46,12 @@ class HooksProcessorTest {
             """
             package com.intuit.hooks.test
 
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(String) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -65,12 +65,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(Map<List<Int>, List<String>>) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
         """
         )
@@ -101,12 +101,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeriesWaterfall<suspend (String) -> String>
-                abstract val testAsyncSeriesWaterfallHook: AsyncSeriesWaterfallHook<*, *>
+                abstract val testAsyncSeriesWaterfallHook: Hook
             }
         """
         )
@@ -147,17 +147,17 @@ class HooksProcessorTest {
             import kotlinx.coroutines.ExperimentalCoroutinesApi
             
             internal abstract class TestHooks : Hooks() {
-                @Sync<(newSpeed: Int) -> Unit> abstract val sync: SyncHook<*>
-                @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: SyncBailHook<*, *>
-                @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: SyncLoopHook<*, *>
-                @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: SyncWaterfallHook<*, *>
+                @Sync<(newSpeed: Int) -> Unit> abstract val sync: Hook
+                @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: Hook
+                @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: Hook
+                @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: Hook
                 @ExperimentalCoroutinesApi
-                @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: AsyncParallelBailHook<*, *>
-                @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: AsyncParallelHook<*>
-                @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: AsyncSeriesHook<*>
-                @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: AsyncSeriesBailHook<*, *>
-                @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: AsyncSeriesLoopHook<*, *>
-                @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: AsyncSeriesWaterfallHook<*, *>
+                @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: Hook
+                @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: Hook
+                @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: Hook
+                @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: Hook
+                @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: Hook
+                @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: Hook
             }
             """
         )
@@ -171,12 +171,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks<T, U> : Hooks() {
                 @Sync<(T) -> U>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -207,13 +207,13 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.HooksDsl
             
             class Controller {
                 abstract class Hooks : HooksDsl() {
                     @Sync<(String) -> Unit>
-                    abstract val testSyncHook: SyncHook<*>
+                    abstract val testSyncHook: Hook
                 }
 
                 val hooks = ControllerHooksImpl()


### PR DESCRIPTION
This enables the user to specify the type once, in the annotation,
without knowing about the correlation between the annotation classes and
the Hook types.

<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines on the ./CONTRIBUTING.md document
-->

# What Changed

## Why

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes

# Release Notes
